### PR TITLE
dependabot scans for WF Proxy and fluent-bit images

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -26,3 +26,8 @@ updates:
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "sigs.k8s.io/*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  - package-ecosystem: "docker"
+    directory: "/.github/docker-dependabot"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 2

--- a/.github/docker-dependabot/dummy-deployment.yaml
+++ b/.github/docker-dependabot/dummy-deployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dummy-dependabot-deployment
+spec:
+  selector:
+    matchLabels:
+      app: dummy
+  template:
+    metadata:
+      labels:
+        app: dummy
+    spec:
+      containers:
+        - name: wf-proxy
+          image: projects.registry.vmware.com/tanzu_observability/proxy:12.0
+        - name: fluent-bit
+          image: cr.fluentbit.io/fluent/fluent-bit:2.0.7


### PR DESCRIPTION
If this works, dependabot should open two PRs for:
- proxy:12.1
- fluent-bit:2.0.8 (which we're already using)

Once a PR is open, manual work from the team is required to _actually_ update the correct files, since dependabot is limited to scanning only K8s Deployment manifests or Helm charts.