### PR TITLE
Don't send prometheus metrics as individual points for control plane histograms

### DIFF
--- a/collector/hack/test/files/all-metrics.jsonl
+++ b/collector/hack/test/files/all-metrics.jsonl
@@ -35,13 +35,10 @@
 {"Name":"kernel.entropy.avail","Tags":{"cluster":"","cluster_uuid":"","source":""}}
 {"Name":"kernel.interrupts","Tags":{"cluster":"","cluster_uuid":"","source":""}}
 {"Name":"kernel.processes.forked","Tags":{"cluster":"","cluster_uuid":"","source":""}}
-{"Name":"kubernetes.controlplane.apiserver.request.duration.seconds.bucket","Tags":{"cluster":"","cluster_uuid":"","le":"","resource":"","scope":"","source":"","verb":""}}
 {"Name":"kubernetes.controlplane.apiserver.request.duration.seconds","Tags":{"cluster":"","cluster_uuid":"","resource":"","scope":"","source":"","verb":""}}
 {"Name":"kubernetes.controlplane.apiserver.request.total.counter","Tags":{"cluster":"","cluster_uuid":"","code":"","group":"","resource":"","scope":"","source":"","verb":""}}
 {"Name":"kubernetes.controlplane.etcd.db.total.size.in.bytes.gauge","Tags":{"cluster":"","cluster_uuid":"","endpoint":"","source":""}}
-{"Name":"kubernetes.controlplane.etcd.request.duration.seconds.bucket","Tags":{"cluster":"","cluster_uuid":"","operation":"","source":"","type":""}}
 {"Name":"kubernetes.controlplane.etcd.request.duration.seconds","Tags":{"cluster":"","cluster_uuid":"","operation":"","source":"","type":""}}
-{"Name":"kubernetes.controlplane.workqueue.queue.duration.seconds.bucket","Tags":{"cluster":"","cluster_uuid":"","le":"","name":"","source":""}}
 {"Name":"kubernetes.controlplane.workqueue.queue.duration.seconds","Tags":{"cluster":"","cluster_uuid":"","name":"","source":""}}
 {"Name":"kubernetes.cadvisor.container.cpu.cfs.throttled.periods.total.counter","Tags":{"cluster":"","cluster_uuid":"","container":"","id":"","image":"","name":"","namespace":"collector-targets","pod":"","source":""}}
 {"Name":"kubernetes.cadvisor.container.cpu.cfs.throttled.periods.total.counter","Tags":{"cluster":"","cluster_uuid":"","id":"","namespace":"","pod":"","source":""}}

--- a/collector/hack/test/files/cluster-metrics-only.jsonl
+++ b/collector/hack/test/files/cluster-metrics-only.jsonl
@@ -2,7 +2,7 @@
 ~{"Name":"disk.total"}
 ~{"Name":"diskio.io.time"}
 ~{"Name":"kernel.boot.time"}
-{"Name":"kubernetes.controlplane.apiserver.request.duration.seconds.bucket"}
+{"Name":"kubernetes.controlplane.apiserver.request.duration.seconds"}
 ~{"Name":"kubernetes.cadvisor.container.cpu.cfs.throttled.periods.total.counter"}
 ~{"Name":"kubernetes.cluster.cpu.limit"}
 {"Name":"kubernetes.collector.discovery.enabled"}

--- a/collector/hack/test/files/node-metrics-only.jsonl
+++ b/collector/hack/test/files/node-metrics-only.jsonl
@@ -2,7 +2,7 @@
 {"Name":"disk.total"}
 {"Name":"diskio.io.time"}
 {"Name":"kernel.boot.time"}
-~{"Name":"kubernetes.controlplane.apiserver.request.duration.seconds.bucket"}
+~{"Name":"kubernetes.controlplane.apiserver.request.duration.seconds"}
 {"Name":"kubernetes.cadvisor.container.cpu.cfs.throttled.periods.total.counter"}
 {"Name":"kubernetes.cluster.cpu.limit"}
 {"Name":"kubernetes.collector.discovery.enabled"}

--- a/collector/plugins/sources/prometheus/point_builder.go
+++ b/collector/plugins/sources/prometheus/point_builder.go
@@ -59,8 +59,9 @@ func (builder *pointBuilder) build(metricFamilies map[string]*prom.MetricFamily)
 				if experimental.IsEnabled(experimental.HistogramConversion) || builder.convertHistograms {
 					point := builder.buildWFHistogram(metricName, m, now, builder.buildTags(m))
 					result = wf.FilterAppend(builder.filters, builder.filtered, result, point)
+				} else {
+					result = append(result, builder.buildHistogramPoints(metricName, m, now, builder.buildTags(m))...)
 				}
-				result = append(result, builder.buildHistogramPoints(metricName, m, now, builder.buildTags(m))...)
 			} else {
 				result = append(result, builder.buildPoints(metricName, m, now)...)
 			}

--- a/collector/plugins/sources/prometheus/prometheus_example_test.go
+++ b/collector/plugins/sources/prometheus/prometheus_example_test.go
@@ -109,6 +109,42 @@ http_request_duration_seconds_count 144320
 	experimental.DisableFeature(experimental.HistogramConversion)
 }
 
+func TestParsePrometheusHistogramOnlyCreateDistributions(t *testing.T) {
+	src := &prometheusMetricsSource{
+		convertHistograms: true,
+	}
+
+	metrics, err := src.parseMetrics(bytes.NewReader([]byte(`
+# A histogram, which has a pretty complex representation in the text format:
+# HELP http_request_duration_seconds A histogram of the request duration.
+# TYPE http_request_duration_seconds histogram
+http_request_duration_seconds_bucket{le="0.05"} 24054
+http_request_duration_seconds_bucket{le="0.2"} 100392
+http_request_duration_seconds_bucket{le="0.1"} 33444
+http_request_duration_seconds_bucket{le="0.5"} 129389
+http_request_duration_seconds_bucket{le="1"} 133988
+http_request_duration_seconds_bucket{le="+Inf"} 144320
+http_request_duration_seconds_sum 53423
+http_request_duration_seconds_count 144320
+`)))
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(metrics))
+
+	distribution, ok := metrics[0].(*wf.Distribution)
+	require.True(t, ok)
+	assert.Equal(t, 6, len(distribution.Centroids))
+	expectedCentroids := []wf.Centroid{
+		{Value: 0.05, Count: 24054},
+		{Value: 0.1, Count: 33444},
+		{Value: 0.2, Count: 100392},
+		{Value: 0.5, Count: 129389},
+		{Value: 1.0, Count: 133988},
+		{Value: math.Inf(1), Count: 144320},
+	}
+	assert.Equal(t, expectedCentroids, distribution.Centroids)
+}
+
 func TestFilteringWFHistogramPoints(t *testing.T) {
 	experimental.EnableFeature(experimental.HistogramConversion)
 	src := &prometheusMetricsSource{


### PR DESCRIPTION
Only send the `WFHistogram` distribution for Prometheus Histograms, not the individual point timeseries.
