### PR TITLE
Disable Logging on GKE clusters.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ delete-gke-cluster: gke-cluster-name-check gke-connect-to-cluster
 create-gke-cluster: gke-cluster-name-check
 	echo "Creating GKE K8s Cluster: $(GKE_CLUSTER_NAME)"
 	gcloud container clusters create $(GKE_CLUSTER_NAME) --machine-type=e2-standard-2 \
-		--zone=$(GCP_REGION)-$(GCP_ZONE) --enable-ip-alias --create-subnetwork range=/21 --num-nodes=$(NUMBER_OF_NODES)
+		--zone=$(GCP_REGION)-$(GCP_ZONE) --enable-ip-alias --create-subnetwork range=/21 --num-nodes=$(NUMBER_OF_NODES) --logging=NONE
 	gcloud container clusters get-credentials $(GKE_CLUSTER_NAME) --zone $(GCP_REGION)-$(GCP_ZONE) --project $(GCP_PROJECT)
 	kubectl create clusterrolebinding --clusterrole cluster-admin \
 		--user $$(gcloud auth list --filter=status:ACTIVE --format="value(account)") \


### PR DESCRIPTION
looks like logging can be disabled by using the config flag --logging=NONE based on the docs: https://cloud.google.com/sdk/gcloud/reference/container/clusters/create

Co-authored by: Glenn Oppegard <goppegard@vmware.com> 