### PR TITLE
Set cluster AppTag in spans.pxl

### DIFF
--- a/operator/hack/autoinstrumentation/spans.pxl
+++ b/operator/hack/autoinstrumentation/spans.pxl
@@ -168,7 +168,6 @@ px.export(
             'service.name': df.destination_service,
             'service.instance.id': df.destination_pod,
 
-            'k8s.cluster.name': df.cluster_name,
             'cluster': df.cluster_name,
 
             # OTEL Scope Exporter Conventions

--- a/operator/hack/autoinstrumentation/spans.pxl
+++ b/operator/hack/autoinstrumentation/spans.pxl
@@ -169,6 +169,7 @@ px.export(
             'service.instance.id': df.destination_pod,
 
             'k8s.cluster.name': df.cluster_name,
+            'cluster': df.cluster_name,
 
             # OTEL Scope Exporter Conventions
             'otel.scope.name': 'pixie',


### PR DESCRIPTION
Lots of the DT features were built on the following Application Tags: `application`, `service`, `cluster`, and `shard`. Since we already have a sensible value for `cluster` of K8s cluster name, let's fill that in for now.