### PR TITLE
Remove amd64 requirement for prom-example-app

### DIFF
--- a/collector/hack/test/deploy/cpu-throttled-prom-example.yaml
+++ b/collector/hack/test/deploy/cpu-throttled-prom-example.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   containers:
   - name: cpu-throttled-prom-example
-    image: projects.registry.vmware.com/tanzu_observability_keights_saas/prometheus-example-app:latest
+    image: projects.registry.vmware.com/tanzu_observability_keights_saas/prometheus-example-app:v0.1.5
     resources:
       requests:
         memory: "64Mi"

--- a/collector/hack/test/deploy/cpu-throttled-prom-example.yaml
+++ b/collector/hack/test/deploy/cpu-throttled-prom-example.yaml
@@ -12,8 +12,6 @@ metadata:
   name: cpu-throttled-prom-example
   namespace: collector-targets
 spec:
-  nodeSelector:
-    kubernetes.io/arch: amd64
   containers:
   - name: cpu-throttled-prom-example
     image: projects.registry.vmware.com/tanzu_observability_keights_saas/prometheus-example-app:latest

--- a/collector/hack/test/deploy/exclude-prom-example.yaml
+++ b/collector/hack/test/deploy/exclude-prom-example.yaml
@@ -13,8 +13,6 @@ metadata:
   name: exclude-prom-example
   namespace: collector-targets
 spec:
-  nodeSelector:
-    kubernetes.io/arch: amd64
   containers:
   - name: exclude-prom-example
     image: projects.registry.vmware.com/tanzu_observability_keights_saas/prometheus-example-app:latest

--- a/collector/hack/test/deploy/exclude-prom-example.yaml
+++ b/collector/hack/test/deploy/exclude-prom-example.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   containers:
   - name: exclude-prom-example
-    image: projects.registry.vmware.com/tanzu_observability_keights_saas/prometheus-example-app:latest
+    image: projects.registry.vmware.com/tanzu_observability_keights_saas/prometheus-example-app:v0.1.5
     imagePullPolicy: Always
     command:
     - /bin/prometheus-example-app

--- a/collector/hack/test/deploy/load-test-prom-example.yaml
+++ b/collector/hack/test/deploy/load-test-prom-example.yaml
@@ -30,8 +30,6 @@ spec:
       name: prom-example
       namespace: load-test
     spec:
-      nodeSelector:
-        kubernetes.io/arch: amd64
       containers:
       - name: prom-example
         image: projects.registry.vmware.com/tanzu_observability_keights_saas/prometheus-example-app:latest

--- a/collector/hack/test/deploy/load-test-prom-example.yaml
+++ b/collector/hack/test/deploy/load-test-prom-example.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: prom-example
-        image: projects.registry.vmware.com/tanzu_observability_keights_saas/prometheus-example-app:latest
+        image: projects.registry.vmware.com/tanzu_observability_keights_saas/prometheus-example-app:v0.1.5
         imagePullPolicy: Always
         command:
           - /bin/prometheus-example-app

--- a/collector/hack/test/deploy/prom-example.yaml
+++ b/collector/hack/test/deploy/prom-example.yaml
@@ -12,8 +12,6 @@ metadata:
   name: prom-example
   namespace: collector-targets
 spec:
-  nodeSelector:
-    kubernetes.io/arch: amd64
   containers:
   - name: prom-example
     image: projects.registry.vmware.com/tanzu_observability_keights_saas/prometheus-example-app:latest

--- a/collector/hack/test/deploy/prom-example.yaml
+++ b/collector/hack/test/deploy/prom-example.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   containers:
   - name: prom-example
-    image: projects.registry.vmware.com/tanzu_observability_keights_saas/prometheus-example-app:latest
+    image: projects.registry.vmware.com/tanzu_observability_keights_saas/prometheus-example-app:v0.1.5
     imagePullPolicy: Always
     command:
     - /bin/prometheus-example-app


### PR DESCRIPTION
It has been cross-compiled and pushed so that collector integration tests work on M1 Macs and also work on arm64 CI nodes.