### PR TITLE
Separate use of `local` and command substitution

### DIFF
--- a/collector/hack/code-health-and-support/command/git-test-commit.sh
+++ b/collector/hack/code-health-and-support/command/git-test-commit.sh
@@ -3,9 +3,11 @@
 function gtc() {
     local message=$1
     # TODO automatically launch kind if not running
-    local kind_clusters=$(kind get clusters 2>&1 1>/dev/null)
+    local kind_clusters
+    kind_clusters=$(kind get clusters 2>&1 1>/dev/null)
 
-    local start_time=`date +%s`
+    local start_time
+    start_time=$(date +%s)
 
     if [ "${kind_clusters}" = "No kind clusters found." ]; then
         make nuke-kind
@@ -14,9 +16,11 @@ function gtc() {
     make tests || return 1
     make integration-test || return 1
 
-    local end_time=`date +%s`
+    local end_time
+    end_time=$(date +%s)
 
-    local total_runtime=$((end_time-start_time))
+    local total_runtime
+    total_runtime=$((end_time-start_time))
     git status
     git commit -m "${message}
 
@@ -26,7 +30,8 @@ function gtc() {
 
 function borkWIP() {
     local message=$1
-    local borked_branch=$(git rev-parse --abbrev-ref HEAD)
+    local borked_branch
+    borked_branch=$(git rev-parse --abbrev-ref HEAD)
     if [[ $borked_branch != "BORKWIP/"* ]]; then
         git checkout -b "BORKWIP/${borked_branch}"
         borked_branch="BORKWIP/${borked_branch}"
@@ -38,7 +43,8 @@ function borkWIP() {
 
 function unBork() {
     local message=$1
-    local borked_branch=$(git rev-parse --abbrev-ref HEAD)
+    local borked_branch
+    borked_branch=$(git rev-parse --abbrev-ref HEAD)
     if [[ $borked_branch != "BORKWIP/"* ]]; then
         echo 'you are already unborked.'
         exit 1

--- a/collector/hack/test/deploy.sh
+++ b/collector/hack/test/deploy.sh
@@ -35,7 +35,8 @@ function main() {
   local K8S_ENV=
 
   # OPTIONAL/DEFAULT
-  local VERSION="$(cat "${COLLECTOR_REPO_ROOT}"/release/VERSION)"
+  local VERSION
+  VERSION="$(cat "${COLLECTOR_REPO_ROOT}"/release/VERSION)"
   local K8S_CLUSTER_NAME=
   local COLLECTOR_YAML=
   local COLLECTOR_CONFIG_YAML=

--- a/collector/hack/test/generate.sh
+++ b/collector/hack/test/generate.sh
@@ -77,11 +77,16 @@ function main() {
   local WAVEFRONT_TOKEN=
 
   # OPTIONAL/DEFAULT
-  local VERSION="$(cat "${COLLECTOR_REPO_ROOT}"/release/VERSION)"
-  local K8S_ENV=$(k8s_env | awk '{print tolower($0)}')
-  local K8S_CLUSTER_NAME=$(whoami)-${K8S_ENV}-$(date +"%y%m%d")
-  local COLLECTOR_YAML="${COLLECTOR_REPO_ROOT}/deploy/kubernetes/5-collector-daemonset.yaml"
-  local COLLECTOR_CONFIG_YAML="${COLLECTOR_REPO_ROOT}/hack/test/base/collector-config.template.yaml"
+  local VERSION
+  VERSION="$(cat "${COLLECTOR_REPO_ROOT}"/release/VERSION)"
+  local K8S_ENV
+  K8S_ENV=$(k8s_env | awk '{print tolower($0)}')
+  local K8S_CLUSTER_NAME
+  K8S_CLUSTER_NAME=$(whoami)-${K8S_ENV}-$(date +"%y%m%d")
+  local COLLECTOR_YAML
+  COLLECTOR_YAML="${COLLECTOR_REPO_ROOT}/deploy/kubernetes/5-collector-daemonset.yaml"
+  local COLLECTOR_CONFIG_YAML
+  COLLECTOR_CONFIG_YAML="${COLLECTOR_REPO_ROOT}/hack/test/base/collector-config.template.yaml"
   local USE_TEST_PROXY="false"
   local EXPERIMENTAL_FEATURES=
 

--- a/collector/hack/test/test-integration.sh
+++ b/collector/hack/test/test-integration.sh
@@ -103,8 +103,10 @@ function main() {
   local VERSION=
 
   # OPTIONAL/DEFAULT
-  local K8S_ENV=$(k8s_env | awk '{print tolower($0)}')
-  local K8S_CLUSTER_NAME=$(whoami)-${K8S_ENV}-$(date +"%y%m%d")
+  local K8S_ENV
+  K8S_ENV=$(k8s_env | awk '{print tolower($0)}')
+  local K8S_CLUSTER_NAME
+  K8S_CLUSTER_NAME=$(whoami)-${K8S_ENV}-$(date +"%y%m%d")
   local EXPERIMENTAL_FEATURES=
   local tests_to_run=()
 

--- a/operator/hack/test/deploy/deploy-local.sh
+++ b/operator/hack/test/deploy/deploy-local.sh
@@ -25,7 +25,8 @@ function main() {
   local WAVEFRONT_LOGGING_TOKEN=
   local WAVEFRONT_URL="https://nimba.wavefront.com"
   local WF_CLUSTER=nimba
-  local CONFIG_CLUSTER_NAME=$(create_cluster_name)
+  local CONFIG_CLUSTER_NAME
+  CONFIG_CLUSTER_NAME=$(create_cluster_name)
 
   while getopts ":c:t:l:n:p:" opt; do
     case $opt in

--- a/operator/hack/test/test-wavefront-metrics.sh
+++ b/operator/hack/test/test-wavefront-metrics.sh
@@ -7,7 +7,8 @@ source "${REPO_ROOT}/scripts/k8s-utils.sh"
 
 function curl_query_to_wf_dashboard() {
   local query=$1
-  local AFTER_UNIX_TS="$(date '+%s')000"
+  local AFTER_UNIX_TS
+  AFTER_UNIX_TS="$(date '+%s')000"
 
   # NOTE: any output inside this function is concatenated and used as the return value;
   # otherwise we would love to put a log such as this in here to give us more information:
@@ -21,7 +22,8 @@ function curl_query_to_wf_dashboard() {
 function wait_for_query_match_tags() {
   local query=$1
   local expected_tags_json=$2
-  local actual_tags_json=$(mktemp)
+  local actual_tags_json
+  actual_tags_json=$(mktemp)
   local loop_count=0
 
   printf "Querying for tags %s ..."  "$query"
@@ -141,8 +143,10 @@ function main() {
   local WAVEFRONT_TOKEN=
   local CONFIG_CLUSTER_NAME=
 
-  local EXPECTED_COLLECTOR_VERSION=$(kubectl get configmaps --namespace observability-system wavefront-component-versions -o yaml | yq '.data.collector' | cut -d '-' -f1)
-  local EXPECTED_OPERATOR_VERSION="$(get_next_operator_version)"
+  local EXPECTED_COLLECTOR_VERSION
+  EXPECTED_COLLECTOR_VERSION=$(kubectl get configmaps --namespace observability-system wavefront-component-versions -o yaml | yq '.data.collector' | cut -d '-' -f1)
+  local EXPECTED_OPERATOR_VERSION
+  EXPECTED_OPERATOR_VERSION="$(get_next_operator_version)"
   local WF_CLUSTER=nimba
   local EXTRA_TESTS=
   local LOGGING_TEST_PROXY_NAME=
@@ -190,8 +194,10 @@ function main() {
 
   wait_for_cluster_ready "$NS"
 
-  local CLUSTER_UUID=$(kubectl get ns default -o json | jq  '.metadata.uid' |  tr -d '"')
-  local EXPECTED_TAGS_JSON=$(mktemp)
+  local CLUSTER_UUID
+  CLUSTER_UUID=$(kubectl get ns default -o json | jq  '.metadata.uid' |  tr -d '"')
+  local EXPECTED_TAGS_JSON
+  EXPECTED_TAGS_JSON=$(mktemp)
   jq -S -n --arg status Healthy \
      --arg proxy Healthy \
      --arg metrics Healthy \

--- a/scripts/combined-deploy.sh
+++ b/scripts/combined-deploy.sh
@@ -11,7 +11,8 @@ source "${REPO_ROOT}/scripts/k8s-utils.sh"
 function main() {
   local BUILD_COLLECTOR=true
   local BUILD_OPERATOR=true
-  local COLLECTOR_VERSION="$(get_component_version collector)"
+  local COLLECTOR_VERSION
+  COLLECTOR_VERSION="$(get_component_version collector)"
 
   while getopts "co" opt; do
     case $opt in
@@ -29,7 +30,8 @@ function main() {
 
   if [[ "${BUILD_COLLECTOR}" == "true" ]]; then
     pushd ${REPO_ROOT}/collector
-      local output="$(PREFIX=${PREFIX} make docker-xplatform-build)"
+      local output
+      output="$(PREFIX=${PREFIX} make docker-xplatform-build)"
       COLLECTOR_VERSION="${output#*Built collector version: }"
     popd
   fi

--- a/scripts/connect-to-gcp-kind.sh
+++ b/scripts/connect-to-gcp-kind.sh
@@ -52,7 +52,8 @@ function main() {
 
   ssh-keygen -F "${KIND_VM_IP}" -f "${known_hosts_filepath}" | grep -q found || ssh-keyscan "${KIND_VM_IP}" >> "${known_hosts_filepath}" 2>/dev/null
 
-  local kind_port=$(fetchKindPort)
+  local kind_port
+  kind_port=$(fetchKindPort)
 
   if [[ -z "${kind_port}" ]]; then
     nukeRemoteKind

--- a/scripts/dashboard-development/create-or-update-dashboard-in-ui.sh
+++ b/scripts/dashboard-development/create-or-update-dashboard-in-ui.sh
@@ -57,7 +57,8 @@ function main() {
 
   jq ".url = \"${NEW_DASHBOARD}\"" ${DASHBOARD_TO_CLONE}.json > ${NEW_DASHBOARD}.json
 
-  local RESULT=$(curl -X PUT --data "$(cat "${NEW_DASHBOARD}".json)" \
+  local RESULT
+  RESULT=$(curl -X PUT --data "$(cat "${NEW_DASHBOARD}".json)" \
     --header "Content-Type: application/json" \
     --header "Authorization: Bearer ${WAVEFRONT_TOKEN}" \
     "https://${WF_CLUSTER}.wavefront.com/api/v2/dashboard/${NEW_DASHBOARD}" \

--- a/scripts/dashboard-development/merge-dashboard.sh
+++ b/scripts/dashboard-development/merge-dashboard.sh
@@ -76,7 +76,8 @@ function main() {
   jq ".url = \"${DEST_DASHBOARD}\"" ${SOURCE_DASHBOARD}.json > ${DEST_DASHBOARD}.json
 
   # Copy dashboard version from integration feature branch and increment it
-  local VERSION=$(($(jq ".systemDashboardVersion" ${INTEGRATION_DIR}/kubernetes/dashboards/${DEST_DASHBOARD}.json 2> /dev/null)+1))
+  local VERSION
+  VERSION=$(($(jq ".systemDashboardVersion" ${INTEGRATION_DIR}/kubernetes/dashboards/${DEST_DASHBOARD}.json 2> /dev/null)+1))
   jq ". += {"systemDashboardVersion":${VERSION}}" ${DEST_DASHBOARD}.json > "tmp" && mv "tmp" ${DEST_DASHBOARD}.json
 
   # Do the sorting here so our systemDashboardVersion gets bumped to the top of the file

--- a/scripts/osl-check.sh
+++ b/scripts/osl-check.sh
@@ -42,15 +42,20 @@ function main() {
         branch_start='main'
     fi
 
-    local additions_file=$(mktemp)
-    local removals_file=$(mktemp)
+    local additions_file
+    additions_file=$(mktemp)
+    local removals_file
+    removals_file=$(mktemp)
 
     git diff "${branch_start}..HEAD" -- "${component}/go.mod" | grep -e '^+\s' | awk '{print $2}' | sort > "${additions_file}"
     git diff "${branch_start}..HEAD" -- "${component}/go.mod" | grep -e '^-\s' | awk '{print $2}' | sort > "${removals_file}"
 
-    local added_packages_file=$(mktemp)
-    local removed_packages_file=$(mktemp)
-    local upgraded_packages_file=$(mktemp)
+    local added_packages_file
+    added_packages_file=$(mktemp)
+    local removed_packages_file
+    removed_packages_file=$(mktemp)
+    local upgraded_packages_file
+    upgraded_packages_file=$(mktemp)
 
     comm -23 "${additions_file}" "${removals_file}" > "${added_packages_file}"
     comm -23 "${removals_file}" "${additions_file}" > "${removed_packages_file}"


### PR DESCRIPTION
Failures in the command substitution will correctly cause the script to exit when the `-e` flag is set.

 It wasn't failing before because `local` itself returns a status of `0`. The assignment of a failed command substitution does not cause `local`to return non-zero. Therefore, no immediate-exit is triggered.

See https://stackoverflow.com/a/34914900/1131034