### PR TITLE
use an absolute path for bin shims

### DIFF
--- a/bin/controller-gen
+++ b/bin/controller-gen
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BIN_DIR=$(dirname "$0")
+BIN_DIR=$(dirname $(realpath "$0"))
 
 VERSION=0.11.3
 

--- a/bin/gcloud
+++ b/bin/gcloud
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BIN_DIR=$(dirname "$0")
+BIN_DIR=$(dirname $(realpath "$0"))
 
 VERSION=440.0.0
 

--- a/bin/goimports
+++ b/bin/goimports
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BIN_DIR=$(dirname "$0")
+BIN_DIR=$(dirname $(realpath "$0"))
 
 VERSION=0.11.0
 

--- a/bin/golangci-lint
+++ b/bin/golangci-lint
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BIN_DIR=$(dirname "$0")
+BIN_DIR=$(dirname $(realpath "$0"))
 
 VERSION=1.53.2
 

--- a/bin/helm
+++ b/bin/helm
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BIN_DIR=$(dirname "$0")
+BIN_DIR=$(dirname $(realpath "$0"))
 
 HELM_VERSION=3.12.2
 HELM_OS=$(go env GOOS)

--- a/bin/imgpkg
+++ b/bin/imgpkg
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BIN_DIR=$(dirname "$0")
+BIN_DIR=$(dirname $(realpath "$0"))
 
 VERSION=0.33.0
 

--- a/bin/kube-linter
+++ b/bin/kube-linter
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BIN_DIR=$(dirname "$0")
+BIN_DIR=$(dirname $(realpath "$0"))
 
 VERSION=0.4.0
 

--- a/bin/kube-score
+++ b/bin/kube-score
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BIN_DIR=$(dirname "$0")
+BIN_DIR=$(dirname $(realpath "$0"))
 
 VERSION=1.14.0
 

--- a/bin/kubectl
+++ b/bin/kubectl
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BIN_DIR=$(dirname "$0")
+BIN_DIR=$(dirname $(realpath "$0"))
 
 VERSION=1.24.15
 

--- a/bin/kustomize
+++ b/bin/kustomize
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BIN_DIR=$(dirname "$0")
+BIN_DIR=$(dirname $(realpath "$0"))
 
 VERSION=5.0.3 # Ignore 5.1.0 because they forgot to publish a darwin/arm64 version
 

--- a/bin/semver-cli
+++ b/bin/semver-cli
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BIN_DIR=$(dirname "$0")
+BIN_DIR=$(dirname $(realpath "$0"))
 
 VERSION=latest
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -239,6 +239,7 @@ undeploy: operator-yaml
 	kubectl delete --ignore-not-found=$(ignore-not-found) -n $(NS) secret wavefront-secret || true
 	kubectl delete --ignore-not-found=$(ignore-not-found) -k $(OPERATOR_BUILD_DIR) || true
 
+
 .PHONY: integration-test
 integration-test: undeploy deploy
 	(cd $(OPERATOR_DIR)/hack/test && ./run-e2e-tests.sh -t $(WAVEFRONT_TOKEN) -d $(NS) -v $(NEXT_RELEASE_VERSION) $(INTEGRATION_TEST_ARGS))


### PR DESCRIPTION
Some versions of Go want an absolute path for `GOBIN`. I decided to change how we compute `BIN_DIR` for every bin shim for consistency's sake.