### PR TITLE
OSM pipeline fixes

### DIFF
--- a/osspi/pipeline.yaml
+++ b/osspi/pipeline.yaml
@@ -76,7 +76,6 @@ jobs:
               include_bomtools: "go_mod"
               search_depth: 5
               go_mod.path: "/go/bin/go"
-
               # exclude for signature scans
               exclude_patterns:
                 - vendor
@@ -117,10 +116,10 @@ jobs:
               include_bomtools: "go_mod"
               search_depth: 5
               go_mod.path: "/go/bin/go"
-
               # exclude for signature scans
               exclude_patterns:
                 - vendor
+                - pixie-sizer
             OSSPI_IGNORE_RULES: |
               - name_regex: onsi\/ginkgo
                 version_regex: .*
@@ -150,7 +149,6 @@ jobs:
               include_bomtools: "go_mod"
               search_depth: 5
               go_mod.path: "/go/bin/go"
-
               # exclude for signature scans
               exclude_patterns:
                 - vendor
@@ -160,7 +158,7 @@ jobs:
               - name_regex: gomega
                 version_regex: .*
         - task: osspi-scan-fluentbit
-          timeout: 10m
+          timeout: 30m
           file: observability-for-kubernetes/osspi/tasks/osspi/run-osspi-docker.yaml
           input_mapping:
             ci_repo: observability-for-kubernetes

--- a/osspi/pipeline.yaml
+++ b/osspi/pipeline.yaml
@@ -90,7 +90,7 @@ jobs:
         - get: observability-for-kubernetes
           trigger: true
           params: { submodules: all }
-      - in_parallel:
+      - do:
         - task: osspi-scan-packages
           attempts: 3
           file: observability-for-kubernetes/osspi/tasks/osspi/run-osspi-source.yaml
@@ -135,6 +135,7 @@ jobs:
             VERSION: Latest
             PREPARE: |
               go mod tidy && go mod vendor
+            OSM_PACKAGE_GROUP_NAME: pixie-sizer
             OSSPI_SCANNING_PARAMS: |
               enable: true
               include_bomtools: "go_mod"

--- a/osspi/pipeline.yaml
+++ b/osspi/pipeline.yaml
@@ -1,32 +1,24 @@
-resource_types:
-  - name: gitlab
-    type: registry-image
-    source:
-      repository: devtools-docker.artifactory.eng.vmware.com/vmware/runway/resourcetypes/gitlab-resource
-      tag: 1.0.0
 resources:
   - name: observability-for-kubernetes
     type: git
     source:
-      uri: git@github.com:wavefrontHQ/observability-for-kubernetes.git
-      private_key: ((osspi.jcornish-github-private-key)) # TODO use a deploy key
+      uri: https://github.com/wavefrontHQ/observability-for-kubernetes.git
   - name: osspi-tool
     type: git
     icon: gitlab
     source:
-      uri: git@gitlab.eng.vmware.com:source-insight-tooling/norsk-to-osspi.git
-      private_key: ((osspi.jcornish-github-private-key)) # TODO use a deploy key
+      uri: https://gitlab.eng.vmware.com/source-insight-tooling/norsk-to-osspi.git
+      username: 13906 # From goppegard's gitlab profile
+      password: ((osspi.goppegard-gitlab-pat))
       branch: main
   - name: wavefront-kubernetes-adapter
     type: git
     source:
-      uri: git@github.com:wavefrontHQ/wavefront-kubernetes-adapter.git
-      private_key: ((osspi.jcornish-github-private-key)) # TODO use a deploy key
+      uri: https://github.com/wavefrontHQ/wavefront-kubernetes-adapter.git
   - name: prometheus-storage-adapter
     type: git
     source:
-      uri: git@github.com:wavefrontHQ/prometheus-storage-adapter.git
-      private_key: ((osspi.jcornish-github-private-key)) # TODO use a deploy key
+      uri: https://github.com/wavefrontHQ/prometheus-storage-adapter.git
   - name: wavefront-sdk-java
     source:
       uri: https://github.com/wavefrontHQ/wavefront-sdk-java.git

--- a/osspi/pipeline.yaml
+++ b/osspi/pipeline.yaml
@@ -92,7 +92,8 @@ jobs:
           params: { submodules: all }
       - do:
         - task: osspi-scan-packages
-          attempts: 3
+          timeout: 30m
+          attempts: 2
           file: observability-for-kubernetes/osspi/tasks/osspi/run-osspi-source.yaml
           input_mapping:
             ci_repo: observability-for-kubernetes
@@ -101,11 +102,14 @@ jobs:
             SCAN_PATH: operator
             REPO: project_repo
             API_KEY: ((osspi.osm-prod-api-key))
+            OSM_PACKAGE_GROUP_NAME: operator
             USERNAME: ((osspi.osm-prod-username))
             PRODUCT: Wavefront_K8_Operator
             VERSION: Latest
             PREPARE: |
-              go mod vendor
+              GOMOD_VERSION=$(go list -m -f '{{.GoVersion}}') \
+              && go env -w GOTOOLCHAIN=go$GOMOD_VERSION \
+              && go mod vendor
             OSSPI_SCANNING_PARAMS: |
               enable: true
               include_bomtools: "go_mod"
@@ -121,7 +125,8 @@ jobs:
               - name_regex: gomega
                 version_regex: .*
         - task: osspi-scan-pixie-sizer
-          attempts: 3
+          timeout: 30m
+          attempts: 2
           file: observability-for-kubernetes/osspi/tasks/osspi/run-osspi-source.yaml
           input_mapping:
             ci_repo: observability-for-kubernetes
@@ -134,7 +139,9 @@ jobs:
             PRODUCT: Wavefront_K8_Operator
             VERSION: Latest
             PREPARE: |
-              go mod tidy && go mod vendor
+              GOMOD_VERSION=$(go list -m -f '{{.GoVersion}}') \
+              && go env -w GOTOOLCHAIN=go$GOMOD_VERSION \
+              && go mod vendor
             OSM_PACKAGE_GROUP_NAME: pixie-sizer
             OSSPI_SCANNING_PARAMS: |
               enable: true
@@ -151,6 +158,7 @@ jobs:
               - name_regex: gomega
                 version_regex: .*
         - task: osspi-scan-fluentbit
+          timeout: 10m
           file: observability-for-kubernetes/osspi/tasks/osspi/run-osspi-docker.yaml
           input_mapping:
             ci_repo: observability-for-kubernetes

--- a/osspi/pipeline.yaml
+++ b/osspi/pipeline.yaml
@@ -194,7 +194,9 @@ jobs:
           PRODUCT: WavefrontKubernetesAdapter
           VERSION: Latest
           PREPARE: |
-            go mod vendor
+            GOMOD_VERSION=$(go list -m -f '{{.GoVersion}}') && \
+              go env -w GOTOOLCHAIN=go$GOMOD_VERSION && \
+              go mod vendor
           OSSPI_SCANNING_PARAMS: |
             enable: true
             include_bomtools: "go_mod"
@@ -230,7 +232,9 @@ jobs:
           PRODUCT: PrometheusStorageAdapter
           VERSION: Latest
           PREPARE: |
-            go mod vendor
+            GOMOD_VERSION=$(go list -m -f '{{.GoVersion}}') && \
+              go env -w GOTOOLCHAIN=go$GOMOD_VERSION && \
+              go mod vendor
           OSSPI_SCANNING_PARAMS: |
             enable: true
             include_bomtools: "go_mod"

--- a/osspi/pipeline.yaml
+++ b/osspi/pipeline.yaml
@@ -68,7 +68,9 @@ jobs:
             PRODUCT: WavefrontKubernetesCollector
             VERSION: Latest
             PREPARE: |
-              go mod vendor
+              GOMOD_VERSION=$(go list -m -f '{{.GoVersion}}') && \
+                go env -w GOTOOLCHAIN=go$GOMOD_VERSION && \
+                go mod vendor
             OSSPI_SCANNING_PARAMS: |
               enable: true
               include_bomtools: "go_mod"
@@ -107,9 +109,9 @@ jobs:
             PRODUCT: Wavefront_K8_Operator
             VERSION: Latest
             PREPARE: |
-              GOMOD_VERSION=$(go list -m -f '{{.GoVersion}}') \
-              && go env -w GOTOOLCHAIN=go$GOMOD_VERSION \
-              && go mod vendor
+              GOMOD_VERSION=$(go list -m -f '{{.GoVersion}}') && \
+                go env -w GOTOOLCHAIN=go$GOMOD_VERSION && \
+                go mod vendor
             OSSPI_SCANNING_PARAMS: |
               enable: true
               include_bomtools: "go_mod"
@@ -139,9 +141,9 @@ jobs:
             PRODUCT: Wavefront_K8_Operator
             VERSION: Latest
             PREPARE: |
-              GOMOD_VERSION=$(go list -m -f '{{.GoVersion}}') \
-              && go env -w GOTOOLCHAIN=go$GOMOD_VERSION \
-              && go mod vendor
+              GOMOD_VERSION=$(go list -m -f '{{.GoVersion}}') && \
+                go env -w GOTOOLCHAIN=go$GOMOD_VERSION && \
+                go mod vendor
             OSM_PACKAGE_GROUP_NAME: pixie-sizer
             OSSPI_SCANNING_PARAMS: |
               enable: true


### PR DESCRIPTION
- Exclude `pixie-sizer` when scanning `operator/` dir
- Use correct go version via `GOTOOLCHAIN` feature
- Swap out OSM creds